### PR TITLE
Patch for Power++

### DIFF
--- a/1.2/Defs/ThingDefs_Buildings/Buildings_Ultra.xml
+++ b/1.2/Defs/ThingDefs_Buildings/Buildings_Ultra.xml
@@ -63,7 +63,6 @@
                 <compClass>CompPowerTrader</compClass>
                 <shortCircuitInRain>true</shortCircuitInRain>
                 <basePowerConsumption>2200</basePowerConsumption>
-                <transmitsPower>true</transmitsPower>
             </li>
             <li Class="CompProperties_Refuelable">
                 <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>


### PR DESCRIPTION
Recently i'm using Power++ and notice that sleeve incubator can't connect to LWPN. So i look into the source code and find that sleeve incubator have tag `<transmitsPower>true</transmitsPower>` even it is not a power generator. 

After I remove the tag and test it, it can connect to LWPN.

# Issue 
* Sleeve incubator can't connect to LWPN from Power++.

# Solution
* Remove tag `<transmitsPower>true</transmitsPower>` from sleeve incubator.